### PR TITLE
加一個主色 & 加卡片badge的樣式

### DIFF
--- a/assets/scss/all.scss
+++ b/assets/scss/all.scss
@@ -17,6 +17,7 @@
 @import "./components/button";
 @import "./components/filter-tag";
 @import "./components/avatar";
+@import "./components/card-badge";
 
 @import './layout/header';
 @import './layout/footer';

--- a/assets/scss/components/_card-badge.scss
+++ b/assets/scss/components/_card-badge.scss
@@ -1,0 +1,11 @@
+.badge {
+    line-height: 1.5;
+    &-primary {
+        background: $primary-50;
+        color: $primary;
+    }
+    &-alert {
+        background: $danger-100;
+        color: $danger;
+    }
+}

--- a/assets/scss/helpers/_custom-colors.scss
+++ b/assets/scss/helpers/_custom-colors.scss
@@ -1,5 +1,6 @@
 $primary: #0068FF;
 $primary-dark: #003BB7;
+$primary-50: #E5F4FF;
 $primary-100: #99CFFF;
 $primary-200: #66B1FF;
 $primary-300: #3F95FF;

--- a/assets/scss/helpers/_variables.scss
+++ b/assets/scss/helpers/_variables.scss
@@ -1550,11 +1550,11 @@ $toast-header-border-color:         $toast-border-color !default;
 // Badges
 
 // scss-docs-start badge-variables
-$badge-font-size:                   .75em !default;
+$badge-font-size:                   $h8-font-size; // .75em !default; Custom
 $badge-font-weight:                 $font-weight-bold !default;
 $badge-color:                       $white !default;
-$badge-padding-y:                   .35em !default;
-$badge-padding-x:                   .65em !default;
+$badge-padding-y:                   8px; //.35em !default; Custom
+$badge-padding-x:                   12px; // .65em !default; Custom
 $badge-border-radius:               var(--#{$prefix}border-radius) !default;
 // scss-docs-end badge-variables
 


### PR DESCRIPTION
1. 主色少了個最淺的色系 `$primary-50: #E5F4FF;` 已加在 `_custom-colors.scss` 
2. 在`_variables.scss`中更改 badge 的字級 + padding
3. 新增`_card-badge.scss`放置其他樣式設定。需要做卡片的人可取用～