### PR TITLE
加入小的badge & 修正 avatar 樣式

### DIFF
--- a/assets/scss/base/_base.scss
+++ b/assets/scss/base/_base.scss
@@ -16,4 +16,5 @@ p {
 ul,li {
     list-style: none;
     padding: 0;
+    margin: 0;
 }

--- a/assets/scss/components/_avatar.scss
+++ b/assets/scss/components/_avatar.scss
@@ -1,13 +1,12 @@
-.card-avatar {
-    height: 44px;
-    width: 44px;
-    border-radius: 50%;
-    overflow: hidden;
-    position: relative;
+.card-avatar-wrapper {
+    display: flex;
+    align-items: center;
 }
 
 .avatar-img {
-    // width: 100%;
-    // object-fit: cover;
-    transform: scale(1.6) translateY(4px); 
+    height: 44px;
+    width: 44px;
+    border-radius: 50%;
+    object-fit: cover;
+    margin-right: 8px;
 }

--- a/assets/scss/components/_card-badge.scss
+++ b/assets/scss/components/_card-badge.scss
@@ -1,5 +1,14 @@
 .badge {
     line-height: 1.5;
+    position: absolute;
+    top: 16px;
+    left: 16px;
+    &-sm {
+        font-weight: $font-weight-normal;
+        padding: 4px 8px;
+        top: 4px;
+        left: 4px;
+    }
     &-primary {
         background: $primary-50;
         color: $primary;


### PR DESCRIPTION
1. 在 `_card-badge.scss` 加入 `.card-badge-sm`，因為發現「nav 探索選單、行動版的綜合結果與搜尋結果」中的card有用到。Ariel 做 navbar 可取用
2. 修正 avatar 樣式
3. 在 `_base.scss` 給 ol ul 加 `margin:0`